### PR TITLE
Package `tailwindcss-rails` as a separate Nix derivation

### DIFF
--- a/gemset.nix
+++ b/gemset.nix
@@ -1848,27 +1848,6 @@
     };
     version = "0.15.0";
   };
-  tailwindcss-rails = {
-    dependencies = ["railties" "tailwindcss-ruby"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "02vg7lbb95ixx9m6bgm2x0nrcm4dxyl0dcsd7ygg6z7bamz32yg8";
-      type = "gem";
-    };
-    version = "3.3.2";
-  };
-  tailwindcss-ruby = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1ip3r3nli0sbcs6qwk87jgk13b1q4sryd1c6iajqr6fy7zfj65g0";
-      type = "gem";
-    };
-    version = "3.4.16";
-  };
   thor = {
     groups = ["default" "development" "test"];
     platforms = [];

--- a/package.nix
+++ b/package.nix
@@ -38,11 +38,14 @@ let
 #      }) 
 #    ];
   };
+
+  tailwindcss-ruby-drv = import ./tailwindcss-ruby.nix { inherit pkgs ruby; };
+  tailwindcss-rails-drv = import ./tailwindcss-rails.nix { inherit pkgs ruby; railties = gems.railties; tailwindcss-ruby = tailwindcss-ruby-drv; };
 in
 stdenv.mkDerivation {
   name = "dawarich";
   inherit src;
-  buildInputs = [ gems ruby gems.wrappedRuby pkgs.rubyPackages_3_4.sqlite3 pkgs.tailwindcss ] ++ gemDeps; #pkgs.rubyPackages_3_4.nokogiri] ++ gemDeps;
+  buildInputs = [ gems ruby gems.wrappedRuby pkgs.rubyPackages_3_4.sqlite3 pkgs.tailwindcss tailwindcss-rails-drv ] ++ gemDeps; #pkgs.rubyPackages_3_4.nokogiri] ++ gemDeps;
   
   buildPhase = ''
     cp -r ${src}/. .

--- a/tailwindcss-rails.nix
+++ b/tailwindcss-rails.nix
@@ -1,0 +1,25 @@
+{ pkgs, ruby, railties, tailwindcss-ruby }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "tailwindcss-rails";
+  version = "3.3.2";
+
+  src = pkgs.fetchrubygem {
+    name = "tailwindcss-rails";
+    version = "3.3.2";
+    sha256 = "02vg7lbb95ixx9m6bgm2x0nrcm4dxyl0dcsd7ygg6z7bamz32yg8";
+  };
+
+  buildInputs = [ ruby railties tailwindcss-ruby ];
+
+  # Add other necessary attributes for gem building if any,
+  # like native build inputs or patches.
+  # For now, assume a standard gem build.
+
+  meta = with pkgs.lib; {
+    description = "Rails integration for the Tailwind CSS framework";
+    homepage = "https://github.com/rails/tailwindcss-rails";
+    license = licenses.mit; # Assuming MIT based on common Rails gems
+    platforms = platforms.all;
+  };
+}

--- a/tailwindcss-ruby.nix
+++ b/tailwindcss-ruby.nix
@@ -1,0 +1,24 @@
+{ pkgs, ruby }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "tailwindcss-ruby";
+  version = "3.4.16";
+
+  src = pkgs.fetchrubygem {
+    name = "tailwindcss-ruby";
+    version = "3.4.16";
+    sha256 = "1ip3r3nli0sbcs6qwk87jgk13b1q4sryd1c6iajqr6fy7zfj65g0";
+  };
+
+  buildInputs = [ ruby ];
+
+  # Add other necessary attributes for gem building if any.
+  # For now, assume a standard gem build.
+
+  meta = with pkgs.lib; {
+    description = "Ruby wrapper for the Tailwind CSS CLI";
+    homepage = "https://github.com/excid3/tailwindcss-ruby"; # Common homepage, verify if necessary
+    license = licenses.mit; # Assuming MIT
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
…
Here's what I did:

I moved the Nix derivations for `tailwindcss-rails` and its dependency `tailwindcss-ruby` from `gemset.nix` into their own dedicated files:
- `tailwindcss-rails.nix`
- `tailwindcss-ruby.nix`

The main package derivation in `package.nix` has been updated to import and use these new derivations. The corresponding entries were removed from `gemset.nix`.

This change promotes better modularity and clarity in how Ruby gem dependencies are managed within the Nix build.

Please note: I couldn't directly verify the build in the automated environment. The changes are structurally sound and follow Nix packaging principles, but you should verify the build in a local Nix environment.