### PR TITLE
feat: Add separate nokogiri derivation and use it in dawarich

### DIFF
--- a/gemset.nix
+++ b/gemset.nix
@@ -1032,17 +1032,6 @@
     };
     version = "2.7.4";
   };
-  nokogiri = {
-    dependencies = ["racc"];
-    groups = ["default" "development" "test"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "03i1vhm1x4qjil39lqrhjzc1b6rr6i5f522i98hsdz41n8pdvfin";
-      type = "gem";
-    };
-    version = "1.18.8";
-  };
   oj = {
     dependencies = ["bigdecimal" "ostruct"];
     groups = ["default"];

--- a/nokogiri.nix
+++ b/nokogiri.nix
@@ -1,0 +1,30 @@
+{ pkgs ? import <nixpkgs> {}, stdenv, ruby }:
+
+stdenv.mkDerivation rec {
+  pname = "nokogiri";
+  version = "1.18.8"; # Fetched from gemset.nix
+
+  src = pkgs.fetchrubygem {
+    name = "nokogiri";
+    inherit version;
+    sha256 = "03i1vhm1x4qjil39lqrhjzc1b6rr6i5f522i98hsdz41n8pdvfin"; # Fetched from gemset.nix
+  };
+
+  buildInputs = with pkgs; [
+    libxml2
+    libxslt
+    zlib
+    ruby
+  ] ++ (if pkgs.stdenv.isDarwin then [ libiconv ] else [ ]);
+
+  # If the gem has specific build instructions or patches, add them here.
+  # For many gems, the default buildPhase and installPhase provided by mkDerivation are sufficient.
+
+  meta = with pkgs.lib; {
+    description = "An HTML, XML, SAX, and Reader parser with XPath and CSS selector support";
+    homepage = "https://nokogiri.org";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.Freika ]; # Or your GitHub handle
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -2,6 +2,8 @@
 
 let
   ruby = pkgs.ruby_3_4;
+
+  nokogiriGem = pkgs.callPackage ./nokogiri.nix { inherit ruby; };
   
   # Define system packages needed for gem compilation
   gemDeps = with pkgs; [
@@ -24,7 +26,7 @@ let
   gems = pkgs.bundlerEnv {
     name = "dawarich-gems";
     inherit ruby;
-    buildInputs = [ pkgs.rubyPackages_3_4.nokogiri];
+    buildInputs = [ nokogiriGem ];
     gemdir = ./.;  # Points to current directory where Gemfile, Gemfile.lock, and gemset.nix are located
     
     # Pass build flags to bundler
@@ -42,7 +44,7 @@ in
 stdenv.mkDerivation {
   name = "dawarich";
   inherit src;
-  buildInputs = [ gems ruby gems.wrappedRuby pkgs.rubyPackages_3_4.sqlite3 pkgs.tailwindcss ] ++ gemDeps; #pkgs.rubyPackages_3_4.nokogiri] ++ gemDeps;
+  buildInputs = [ gems ruby gems.wrappedRuby pkgs.rubyPackages_3_4.sqlite3 pkgs.tailwindcss nokogiriGem ] ++ gemDeps;
   
   buildPhase = ''
     cp -r ${src}/. .


### PR DESCRIPTION
This commit introduces a separate Nix derivation for the nokogiri gem in `nokogiri.nix`.

The dawarich package derivation in `package.nix` has been updated to:
- Use this new local nokogiri derivation.
- Remove direct dependencies on `pkgs.rubyPackages_3_4.nokogiri`.

The nokogiri entry has also been removed from `gemset.nix` as it's now managed by its own derivation.