### PR TITLE
Fix: Correct RubyGems fetching and update dependencies

### DIFF
--- a/nokogiri.nix
+++ b/nokogiri.nix
@@ -4,10 +4,9 @@ stdenv.mkDerivation rec {
   pname = "nokogiri";
   version = "1.18.8"; # Fetched from gemset.nix
 
-  src = pkgs.fetchrubygem {
-    name = "nokogiri";
-    inherit version;
-    sha256 = "03i1vhm1x4qjil39lqrhjzc1b6rr6i5f522i98hsdz41n8pdvfin"; # Fetched from gemset.nix
+  src = pkgs.fetchurl {
+    url = "https://rubygems.org/gems/nokogiri-1.18.8.gem";
+    sha256 = "03i1vhm1x4qjil39lqrhjzc1b6rr6i5f522i98hsdz41n8pdvfin";
   };
 
   buildInputs = with pkgs; [

--- a/package.nix
+++ b/package.nix
@@ -12,6 +12,7 @@ let
     zlib
     nodejs
     libiconv
+    postgresql
   ];
   
   # Fetch source from GitHub
@@ -22,6 +23,17 @@ let
 #    sha256 = lib.fakeHash;
   };
   
+# RubyGems Management Strategy:
+# Most gems are managed via `pkgs.bundlerEnv` below. It uses the `Gemfile`,
+# `Gemfile.lock`, and the `gemset.nix` (which is generated from the lock file)
+# to fetch and build gems. `gemset.nix` contains the specific versions and SHA256 hashes.
+#
+# Gems that require special build steps, patches, or have complex system dependencies
+# not easily handled by `bundlerEnv` directly (e.g., nokogiri) are packaged individually
+# in separate .nix files (e.g., `nokogiri.nix`). These are then imported using `pkgs.callPackage`
+# and typically use `pkgs.fetchurl` to get their source from rubygems.org.
+# These individually packaged gems are then often included in the `buildInputs` of `bundlerEnv`
+# or the main derivation if they are needed during the build of other gems or the application itself.
   # Create a bundler environment with all dependencies
   gems = pkgs.bundlerEnv {
     name = "dawarich-gems";

--- a/tailwindcss-rails.nix
+++ b/tailwindcss-rails.nix
@@ -4,9 +4,8 @@ pkgs.stdenv.mkDerivation {
   pname = "tailwindcss-rails";
   version = "3.3.2";
 
-  src = pkgs.fetchrubygem {
-    name = "tailwindcss-rails";
-    version = "3.3.2";
+  src = pkgs.fetchurl {
+    url = "https://rubygems.org/gems/tailwindcss-rails-3.3.2.gem";
     sha256 = "02vg7lbb95ixx9m6bgm2x0nrcm4dxyl0dcsd7ygg6z7bamz32yg8";
   };
 

--- a/tailwindcss-ruby.nix
+++ b/tailwindcss-ruby.nix
@@ -4,9 +4,8 @@ pkgs.stdenv.mkDerivation {
   pname = "tailwindcss-ruby";
   version = "3.4.16";
 
-  src = pkgs.fetchrubygem {
-    name = "tailwindcss-ruby";
-    version = "3.4.16";
+  src = pkgs.fetchurl {
+    url = "https://rubygems.org/gems/tailwindcss-ruby-3.4.16.gem";
     sha256 = "1ip3r3nli0sbcs6qwk87jgk13b1q4sryd1c6iajqr6fy7zfj65g0";
   };
 


### PR DESCRIPTION
This commit addresses the issue where `pkgs.fetchrubygem` was being used, which is not a standard Nixpkgs function.

Changes:
- Replaced all instances of `pkgs.fetchrubygem` in `nokogiri.nix`, `tailwindcss-rails.nix`, and `tailwindcss-ruby.nix` with `pkgs.fetchurl`. The URLs now point directly to the .gem files on rubygems.org, and the existing SHA256 hashes are used.
- Added `pkgs.postgresql` to the `gemDeps` in `package.nix`. This is necessary because the `pg` gem (for PostgreSQL integration) is listed in `gemset.nix`, and its native extensions require PostgreSQL development libraries to compile.
- Added a detailed comment in `package.nix` explaining the strategy for managing RubyGems. This clarifies the roles of `pkgs.bundlerEnv`, `gemset.nix`, and the individual packaging of certain gems like Nokogiri.

These changes ensure that the package builds correctly within the Nix environment and provide better clarity for future maintenance.